### PR TITLE
Implementa câmera livre e callback de tecla para mudar câmera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/*
+bin/

--- a/include/globals.h
+++ b/include/globals.h
@@ -157,3 +157,13 @@ extern double g_LastCursorPosX, g_LastCursorPosY;
 // Variáveis que mudam o dígito de cada display
 extern bool isInput1Digit0;
 extern bool isInput2Digit0;
+
+// Variáveis de estado para as teclas de movimentação da câmera
+extern bool W_key_pressed;
+extern bool A_key_pressed;
+extern bool S_key_pressed;
+extern bool D_key_pressed;
+
+// Variável para modificar o tipo de câmera (look-at/free camera)
+extern bool freeCamera;
+extern bool lookatCamera;

--- a/src/callback.cpp
+++ b/src/callback.cpp
@@ -3,6 +3,14 @@
 bool isInput1Digit0 = true;
 bool isInput2Digit0 = true;
 
+// Variáveis de estado para as teclas de movimentação da câmera
+bool W_key_pressed = false;
+bool A_key_pressed = false;
+bool S_key_pressed = false;
+bool D_key_pressed = false;
+bool freeCamera = false;
+bool lookatCamera = true; // câmera padrão
+
 // Definição da função que será chamada sempre que a janela do sistema
 // operacional for redimensionada, por consequência alterando o tamanho do
 // "framebuffer" (região de memória onde são armazenados os pixels da imagem).
@@ -116,6 +124,77 @@ void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mod)
     if (key == GLFW_KEY_R && action == GLFW_PRESS)
     {
         reLoadShaders();
+    }
+
+    // Movimentação da câmera livre
+    if (key == GLFW_KEY_W && freeCamera)
+    {
+        if (action == GLFW_PRESS){
+            W_key_pressed = true;
+        }
+
+        else if (action == GLFW_RELEASE){
+            W_key_pressed = false;
+        }
+
+        else if (action == GLFW_REPEAT){
+            // tecla continua em estado GLFW_PRESS
+        }
+    }
+    if (key == GLFW_KEY_S && freeCamera)
+    {
+        if (action == GLFW_PRESS){
+            S_key_pressed = true;
+        }
+
+        else if (action == GLFW_RELEASE){
+            S_key_pressed = false;
+        }
+
+        else if (action == GLFW_REPEAT){
+            // tecla continua em estado GLFW_PRESS
+        }
+    }
+
+    if (key == GLFW_KEY_A && freeCamera)
+    {
+        if (action == GLFW_PRESS){
+            A_key_pressed = true;
+        }
+
+        else if (action == GLFW_RELEASE){
+            A_key_pressed = false;
+        }
+
+        else if (action == GLFW_REPEAT){
+            // tecla continua em estado GLFW_PRESS
+        }
+    }
+
+    if (key == GLFW_KEY_D && freeCamera)
+    {
+        if (action == GLFW_PRESS){
+            D_key_pressed = true;
+        }
+
+        else if (action == GLFW_RELEASE){
+            D_key_pressed = false;
+        }
+
+        else if (action == GLFW_REPEAT){
+            // tecla continua em estado GLFW_PRESS
+        }
+    }
+
+    // Habilita e desabilita a câmera livre. A câmera padrão é look-at
+    if (key == GLFW_KEY_C && action == GLFW_PRESS)
+    {
+        freeCamera = !freeCamera;
+
+        // Reseta os ângulos da câmera e sua distância para a origem
+        g_CameraTheta = 0.0f; // Ângulo no plano ZX em relação ao eixo Z
+        g_CameraPhi = 0.0f;   // Ângulo em relação ao eixo Y
+        g_CameraDistance = 3.5f; // Distância da câmera para a origem
     }
 }
 


### PR DESCRIPTION
Resolve o item #16, cobre os requisitos #2 e #5
- Implementa câmera livre, com mudança de posição da câmer pelas teclas WASD e mudança de ângulo pelo mouse segurando o botão esquerdo;
- Mapeia a tecla 'C' para a mudança entre câmeras. Câmera look-at inicializa como padrão e pode alternar com a câmera livre;
- Ao alternar entre as câmeras, os parâmetros de ângulo e distância da câmera g_CameraTheta, g_CameraPhi e g_CameraDistance são resetados para seus valores de inicialização. Isso pode ser modificado conforme a experiência pensada.


https://github.com/user-attachments/assets/7b335204-959c-45c9-898c-787d6b98303a


