### PR TITLE
Teste esfera-AABB + renderiza texto para ray cast e mouse coords

### DIFF
--- a/include/collisions.h
+++ b/include/collisions.h
@@ -3,8 +3,9 @@
 
 #include "globals.h"
 
-bool CubeIntersectsCube(AABB a, AABB b);
-bool RayIntersectsCube(glm::vec4 rayOrigin, glm::vec3 rayDirection, AABB cube);
+bool AABBIntersectsAABB(AABB a, AABB b);
+bool RayIntersectsAABB(glm::vec4 rayOrigin, glm::vec3 rayDirection, AABB cube);
+bool SphereIntersectsAABB(Sphere sphere, AABB aabb);
 AABB GetWorldAABB(SceneObject obj, glm::mat4 model);
 glm::vec3 MouseRayCasting(glm::mat4 projectionMatrix, glm::mat4 viewMatrix);
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -101,6 +101,18 @@ struct AABB {
     glm::vec3 max;
 };
 
+/**
+ * @brief Struct que representa uma esfera.
+ * 
+ * Contém as informações necessárias para representar uma esfera no espaço tridimensional.
+ * Ela armazena o centro da esfera e o raio da mesma.
+ */
+struct Sphere {
+    glm::vec3 center;
+    float radius;
+};
+
+
 // Abaixo definimos variáveis globais utilizadas em várias funções do código.
 
 // A cena virtual é uma lista de objetos nomeados, guardados em um dicionário
@@ -182,3 +194,5 @@ extern bool D_key_pressed;
 // Variável para modificar o tipo de câmera (look-at/free camera)
 extern bool freeCamera;
 extern bool lookatCamera;
+
+extern glm::vec3 g_rayPoint;

--- a/include/textrendering.h
+++ b/include/textrendering.h
@@ -19,8 +19,9 @@ void TextRendering_PrintMatrixVectorProductDivW(GLFWwindow* window, glm::mat4 M,
 // Funções abaixo renderizam como texto na janela OpenGL algumas matrizes e
 // outras informações do programa. Definidas após main().
 void TextRendering_ShowModelViewProjection(GLFWwindow* window, glm::mat4 projection, glm::mat4 view, glm::mat4 model, glm::vec4 p_model);
-void TextRendering_ShowEulerAngles(GLFWwindow* window);
+void TextRendering_ShowMouseCoords(GLFWwindow* window);
 void TextRendering_ShowProjection(GLFWwindow* window);
 void TextRendering_ShowFramesPerSecond(GLFWwindow* window);
+void TextRendering_ShowRayCast(GLFWwindow* window);
 
 #endif // _TEXT_RENDERING_H

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -29,7 +29,7 @@ float g_TorsoPositionY = 0.0f;
 
 bool g_UsePerspectiveProjection = true;
 
-bool g_ShowInfoText = true;
+bool g_ShowInfoText = false;
 
 GLuint g_GpuProgramID = 0;
 GLint g_model_uniform;
@@ -42,3 +42,4 @@ GLint g_bbox_max_uniform;
 GLuint g_NumLoadedTextures = 0;
 
 double g_LastCursorPosX, g_LastCursorPosY;
+glm::vec3 g_rayPoint;

--- a/src/textrendering.cpp
+++ b/src/textrendering.cpp
@@ -359,9 +359,8 @@ void TextRendering_ShowModelViewProjection(
     TextRendering_PrintMatrixVectorProductMoreDigits(window, viewport_mapping, p_ndc, -1.0f, 1.0f-26*pad, 1.0f);
 }
 
-// Escrevemos na tela os ângulos de Euler definidos nas variáveis globais
-// g_AngleX, g_AngleY, e g_AngleZ.
-void TextRendering_ShowEulerAngles(GLFWwindow* window)
+// Escrevemos na tela as coordenadas do mouse na janela
+void TextRendering_ShowMouseCoords(GLFWwindow* window)
 {
     if ( !g_ShowInfoText )
         return;
@@ -369,9 +368,23 @@ void TextRendering_ShowEulerAngles(GLFWwindow* window)
     float pad = TextRendering_LineHeight(window);
 
     char buffer[80];
-    snprintf(buffer, 80, "Euler Angles rotation matrix = Z(%.2f)*Y(%.2f)*X(%.2f)\n", g_AngleZ, g_AngleY, g_AngleX);
+    snprintf(buffer, 80, "Cursor = X(%.2f), Y(%.2f)\n", g_LastCursorPosX, g_LastCursorPosY);
 
     TextRendering_PrintString(window, buffer, -1.0f+pad/10, -1.0f+2*pad/10, 1.0f);
+}
+
+// Escrevemos na tela as coordenadas do ponto de ray casting
+void TextRendering_ShowRayCast(GLFWwindow* window)
+{
+    if ( !g_ShowInfoText )
+        return;
+
+    float pad = TextRendering_LineHeight(window);
+
+    char buffer[80];
+    snprintf(buffer, 80, "Raycast = x(%.2f), y(%.2f), z(%.2f)\n", g_rayPoint.x, g_rayPoint.y, g_rayPoint.z);
+
+    TextRendering_PrintString(window, buffer, -1.0f+pad/10, -1.0f+2*pad/1, 1.0f);
 }
 
 // Escrevemos na tela qual matriz de projeção está sendo utilizada.


### PR DESCRIPTION
Resolve item #34 
Resolve parcialmente o requisito #7 

- Cria uma representação de esfera para a câmera (posição e raio);
- Realiza um teste esfera-AABB;
- Para demonstrar, a colisão habilita uma flag que desabilita a movimentação em -w enquanto houver colisão. Para essa funcionalidade ser completa, precisaríamos implementar uma resolução de colisão, calculando um vetor que indica a direção da colisão para recalcular a movimentação da câmera enquanto há colisão;
- Exibe no modo debug (tecla 'H') as coordenadas do mouse e ray casting.

https://github.com/user-attachments/assets/073b0df6-5f87-475d-9085-b18493031611

